### PR TITLE
Updated the Scaler container version to 0.3 in ARM Template

### DIFF
--- a/templates/azuredeploy.json
+++ b/templates/azuredeploy.json
@@ -345,7 +345,7 @@
                                         }
                                     ],
                                     "use32BitWorkerProcess": false,
-                                    "linuxFxVersion": "DOCKER|azurebellhop/scaler:v0.2"
+                                    "linuxFxVersion": "DOCKER|azurebellhop/scaler:v0.3"
                                 }
                             }
                         },


### PR DESCRIPTION
New Scaler has been pushed to DockerHub to address spelling issues in the App Service Plan scaler. Updated the ARM Template to reflect the new scaler container version.