### PR TITLE
Isolate tag errors, Support "Daily" Keyword 

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,7 @@ resize-Enable = <bool> (True/False)
 resize-StartTime = <DateTime> (Friday 7PM)
 resize-EndTime = <DateTime> (Monday 7:30AM)
 ```
+_**NOTE: In addition to given days of the week, the keyword "Daily" can be used in lieu of a specific day if you'd like to trigger scaling every day at a defined time. (Daily 7PM)**_
 
 _**NOTE: StartTime and EndTime are currently in UTC**_
 

--- a/functions/engine/BellhopEngine.cs
+++ b/functions/engine/BellhopEngine.cs
@@ -247,10 +247,9 @@ namespace Bellhop.Function
             //todo: add support for "Daily" keyword
             System.DayOfWeek day;
             
-            //if stamp does not contain dayOfWeek, assume "Daily?
             //if stamp contains "Daily" then resolve to today
             // this assumes that a one-part stamp sets the time and not the day
-            if (parsedStamp.Length == 1 || parsedStamp[0].ToLower().Equals(dailyStr))
+            if (parsedStamp[0].ToLower().Equals(dailyStr))
                 day = DateTime.UtcNow.DayOfWeek;
             else
                 day = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), parsedStamp[0], true);
@@ -260,7 +259,6 @@ namespace Bellhop.Function
             return (day, time);
         }
 
-        // i feel like this logic could go for a few units tests
         public static bool resizeTime(Hashtable times, ILogger log)
         {
             //wrap in try/catch to avoid failing across the board if one tag cannot be correctly parsed
@@ -299,7 +297,7 @@ namespace Bellhop.Function
                 }
 
             }catch (Exception ex){
-                log.LogError(0, ex, "Error calculating resize time");
+                log.LogError(0, ex, $"Error calculating resize time -- StartTime: {(string)times["StartTime"]}  EndTime: {(string)times["EndTime"]}");
             }
             
             return false;

--- a/functions/engine/BellhopEngine.cs
+++ b/functions/engine/BellhopEngine.cs
@@ -52,7 +52,7 @@ namespace Bellhop.Function
             log.LogInformation("Bellhop engine starting up...");
             log.LogInformation("Current UTC Time: " + DateTime.UtcNow.ToString("dddd hh:mm:ss tt"));
 
-            string strQuery = "Resources | where tags['resize-Enable'] =~ 'True'";
+            const string strQuery = "Resources | where tags['resize-Enable'] =~ 'True'";
 
             var resizeUpList = new List<JObject>();
             var resizeDownList = new List<JObject>();
@@ -72,11 +72,11 @@ namespace Bellhop.Function
 			    Debug.Enabled = false;
 		    }
 
-            string storageKeyName = "storageAccount";
+            const string storageKeyName = "storageAccount";
             string storageAppSetting = _configuration[storageKeyName];
             if (Debug.Enabled) log.LogInformation("Storage Account: " + storageAppSetting);
 
-            string queueKeyName = "storageQueue";
+            const string queueKeyName = "storageQueue";
             string queueAppSetting = _configuration[queueKeyName];
             if (Debug.Enabled) log.LogInformation("Storage Queue: " + queueAppSetting);
 


### PR DESCRIPTION
Added a try/catch on resizeTime function so that the entire process doesn't bomb out if a given resource is incorrectly tag. This seems to pan out in my integration testing through having a resource tagged something like 'resize-StartTime = ABC'. Prior to this change having one resource incorrectly tagged appeared to result in an uncaught exception which would globally prevent any scaling operations. 

Separately, added support for "Daily" keyword to allow for scale up/down to occur each day rather than just calendar days weekly. Provided a documentation update to support this keyword. 

I am looking into spinning up some unit tests for the engine code but will do so in a separate branch to limit scope. I believe the date parsing logic would be much more approachable if there were a few defined test cases, and this should help with any future rework of schedule management. 