### PR TITLE
Unit tests

### DIFF
--- a/functions/engine.tests/BellhopEngine.Tests.cs
+++ b/functions/engine.tests/BellhopEngine.Tests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using Xunit;
 
 using Bellhop.Function;
@@ -38,5 +39,63 @@ namespace engine.tests
             Assert.True(day.Equals(DateTime.Now.DayOfWeek), $"Day of week should be {DateTime.Now.DayOfWeek}");
             Assert.True(time.Equals(new TimeSpan(13,0,0)), "Hour should be 1PM (13:00)");
         }
+
+
+        [Fact]
+        public void TestResizeTime_StaticInputs_True()
+        {
+            //Friday April 2 2021 at 10:00
+            DateTime now = new DateTime(2021, 4, 2, 10, 0, 0);
+            Hashtable times = new Hashtable() {
+                {"StartTime", "Friday 9AM"},
+                {"EndTime", "Friday 5PM"}
+            };
+
+            bool result = BellhopEngine.resizeTime(times, now);
+            Assert.True(result, "Result expected true for static inputs inside window");
+        }
+
+        [Fact]
+        public void TestResizeTime_StaticInputs_False()
+        {
+            //Friday April 2 2021 at 10:00
+            DateTime now = new DateTime(2021, 4, 2, 10, 0, 0);
+            Hashtable times = new Hashtable() {
+                {"StartTime", "Friday 8AM"},
+                {"EndTime", "Friday 9AM"}
+            };
+
+            bool result = BellhopEngine.resizeTime(times, now);
+            Assert.False(result, "Result expected false for static inputs outside window");
+        }
+
+        [Fact]
+        public void TestResizeTime_StaticInputs2_True()
+        {
+            //Friday March 19 2021 at 10:00
+            DateTime now = new DateTime(2021, 3, 19, 10, 0, 0);
+            Hashtable times = new Hashtable() {
+                {"StartTime", "Friday 9AM"},
+                {"EndTime", "Friday 5PM"}
+            };
+
+            bool result = BellhopEngine.resizeTime(times, now);
+            Assert.True(result, "Result expected true for static inputs using a predefined 'now' and inputs inside window");
+        }
+
+        [Fact]
+        public void TestResizeTime_StaticInputs2_False()
+        {
+            //Friday March 19 2021 at 10:00
+            DateTime now = new DateTime(2021, 3, 19, 10, 0, 0);
+            Hashtable times = new Hashtable() {
+                {"StartTime", "Friday 8AM"},
+                {"EndTime", "Friday 9AM"}
+            };
+
+            bool result = BellhopEngine.resizeTime(times, now);
+            Assert.False(result, "Result expected false for static inputs using a predefined 'now' and inputs outside window");
+        }
+
     }
 }

--- a/functions/engine.tests/BellhopEngine.Tests.cs
+++ b/functions/engine.tests/BellhopEngine.Tests.cs
@@ -1,0 +1,42 @@
+using System;
+using Xunit;
+
+using Bellhop.Function;
+
+namespace engine.tests
+{
+    public class BellhopEngineTests
+    {
+        [Fact]
+        public void TestGetActionTime_Tuesday9AM()
+        {
+            (System.DayOfWeek day,  TimeSpan time) = BellhopEngine.getActionTime("Tuesday 9AM");
+            Assert.True(day.Equals(DayOfWeek.Tuesday), "Day of week should be Tuesday");
+            Assert.True(time.Equals(new TimeSpan(9,0,0)), "Hour should be 9AM (09:00)");
+        }
+
+        [Fact]
+        public void TestGetActionTime_Friday1PM()
+        {
+            (System.DayOfWeek day,  TimeSpan time) = BellhopEngine.getActionTime("Friday 1PM");
+            Assert.True(day.Equals(DayOfWeek.Friday), "Day of week should be Friday");
+            Assert.True(time.Equals(new TimeSpan(13,0,0)), "Hour should be 1PM (13:00)");
+        }
+
+        [Fact]
+        public void TestGetActionTime_Friday1300()
+        {
+            (System.DayOfWeek day,  TimeSpan time) = BellhopEngine.getActionTime("Friday 13:00");
+            Assert.True(day.Equals(DayOfWeek.Friday), "Day of week should be Friday");
+            Assert.True(time.Equals(new TimeSpan(13,0,0)), "Hour should be 1PM (13:00)");
+        }
+
+        [Fact]
+        public void TestGetActionTime_Daily1300PM()
+        {
+            (System.DayOfWeek day,  TimeSpan time) = BellhopEngine.getActionTime("Daily 13:00");
+            Assert.True(day.Equals(DateTime.Now.DayOfWeek), $"Day of week should be {DateTime.Now.DayOfWeek}");
+            Assert.True(time.Equals(new TimeSpan(13,0,0)), "Hour should be 1PM (13:00)");
+        }
+    }
+}

--- a/functions/engine.tests/engine.tests.csproj
+++ b/functions/engine.tests/engine.tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="1.3.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\engine\bellhop.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/functions/engine/BellhopEngine.cs
+++ b/functions/engine/BellhopEngine.cs
@@ -136,7 +136,7 @@ namespace Bellhop.Function
 
                 Regex rg = new Regex("saveState-.*");
 
-                if (resizeTime(times))
+                if (resizeTime(times, DateTime.Now))
                 {
                     string scaleMessage = "Currently within 'scale down' period ";
 
@@ -258,9 +258,10 @@ namespace Bellhop.Function
             return (day, time);
          }
 
-        public static bool resizeTime(Hashtable times)
+
+        //updated function signature to make more testable
+        public static bool resizeTime(Hashtable times, DateTime now)
         {
-            DateTime now = DateTime.UtcNow;
             var currentDay = now.DayOfWeek;
 
             (var fromDay, var fromTime) = getActionTime((string)times["StartTime"]);
@@ -279,8 +280,9 @@ namespace Bellhop.Function
             var fromUpdate = (fromDay - currentDay);
             var toUpdate = (toDay - currentDay);
 
-            var fromDate = DateTime.Parse(fromTime.ToString()).AddDays(fromUpdate);
-            var toDate = DateTime.Parse(toTime.ToString()).AddDays(toUpdate);
+            //parse the Update times but use 'now' as an anchor to allow for better testability
+            var fromDate = new DateTime(now.Year, now.Month, now.Day, fromTime.Hours, fromTime.Minutes, fromTime.Seconds).AddDays(fromUpdate);
+            var toDate = new DateTime(now.Year, now.Month, now.Day, toTime.Hours, toTime.Minutes, toTime.Seconds).AddDays(toUpdate);
 
             if (now > toDate)
             {

--- a/functions/engine/BellhopEngine.cs
+++ b/functions/engine/BellhopEngine.cs
@@ -238,12 +238,25 @@ namespace Bellhop.Function
             queue.SendMessageAsync(jTarget);
         }
 
-        public static (System.DayOfWeek, TimeSpan) getActionTime(string stamp)
-        {
+         public static (System.DayOfWeek, TimeSpan) getActionTime(string stamp)
+         {
             string[] parsedStamp = stamp.Split(" ");
+            const string dailyStr = "daily";
 
-            return ((DayOfWeek)Enum.Parse(typeof(DayOfWeek), parsedStamp[0], true), Convert.ToDateTime(parsedStamp[1]).TimeOfDay);
-        }
+            //todo: add support for "Daily" keyword
+            System.DayOfWeek day;
+
+            //if stamp contains "Daily" then resolve to today
+            // this assumes that a one-part stamp sets the time and not the day
+            if (parsedStamp[0].ToLower().Equals(dailyStr))
+                day = DateTime.UtcNow.DayOfWeek;
+            else
+                day = (DayOfWeek)Enum.Parse(typeof(DayOfWeek), parsedStamp[0], true);
+
+            TimeSpan time = Convert.ToDateTime(parsedStamp[1]).TimeOfDay;
+
+            return (day, time);
+         }
 
         public static bool resizeTime(Hashtable times)
         {


### PR DESCRIPTION
To execute tests:

```
dotnet test functions/engine/engine.tests.csproj
```

I ended up refactoring the the resizeTime function to support the input of a static DateTime to allow for evaluation against known true and known false inputs. This required a minor tweak to the calculation of the `fromDate` and `toDate` variables to support use of a static anchor for `now`. I believe I have the offsets populating correctly, but another set of eyes would really help. 

I'm not a C# expert. I'm sure there are better ways to architect the tests file as well as overall project testing architecture. I'm just looking to add the capability to have a few unit tests where possible to ensure compatibility going forward. 