### PR TITLE
Fixed issue w/ tagPrefix not being optional

### DIFF
--- a/templates/azuredeploy.json
+++ b/templates/azuredeploy.json
@@ -22,6 +22,7 @@
         },
         "tagPrefix": {
             "type": "string",
+            "defaultValue": "",
             "metadata": {
                 "description": "Prefix which will Bellhop will expect to be prepended to all tags."
             }
@@ -166,6 +167,7 @@
                         },
                         "tagPrefix": {
                             "type": "string",
+                            "defaultValue": "",
                             "metadata": {
                                 "description": "Prefix which will Bellhop will expect to be prepended to all tags."
                             }


### PR DESCRIPTION
Update ARM Template to use defaultValue of an empty string when tagPrefix isn't set in the CreateUiDef during deployment.