### PR TITLE
Fixing Action Group ShortName limit of 12 chars

### DIFF
--- a/templates/azuredeploy.json
+++ b/templates/azuredeploy.json
@@ -312,7 +312,7 @@
                         "appInsightsName": "[concat(parameters('appName'), '-appinsights')]",
                         "appConfigName": "[concat(parameters('appName'), '-appconfig')]",
                         "actionGroupName": "[concat(parameters('appName'), '-actionGroup')]",
-                        "actionGroupShortName": "[concat(parameters('appName'), '-ag')]",
+                        "actionGroupShortName": "[concat(take(parameters('appName'), 9), '-ag')]",
                         "appConfigReaderRole": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '516239f1-63e1-4d78-a4de-a74fb236a071')]",
                         "storageQueueDataMessageSenderRole": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'c6a89b2d-59bc-44d0-9896-0f6e12d7b80a')]",
                         "alertRules": [


### PR DESCRIPTION
Fixing bug Sumit identified to limit the Action Group short name to a max of 12 chars in the ARM template.