### PR TITLE
Fixed LicenseType issue w/ DTU type SQL Database

### DIFF
--- a/functions/scaler/BellhopScaler/scalers/microsoft.sql/servers/databases/function.psm1
+++ b/functions/scaler/BellhopScaler/scalers/microsoft.sql/servers/databases/function.psm1
@@ -51,9 +51,10 @@ function Update-Resource {
             # Data to be stored as Tags to remember the current stats of the object
             $saveData = @{
                 RequestedServiceObjectiveName = $graphData.properties.requestedServiceObjectiveName
-                LicenseType = $graphData.properties.licenseType
                 MaxSizeBytes = $graphData.properties.maxSizeBytes
             }
+
+            if ( $graphData.properties.licenseType ) { $saveData.Add("LicenseType", $graphData.properties.licenseType) }
 
             $config += $baseData
             $tags += Set-SaveTags $saveData $tagData.map


### PR DESCRIPTION
On DTU type SQL Databases, the field "LicenseType" is not present. The scaler needs to remember this for vCore to ensure Azure Hybrid Benefits is placed back onto the object once it's scaled back up. Added an "if" check to determine if the key is present, and if so save it to the saveData tags.